### PR TITLE
WIP: adds digitizer setter

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,3 +1,6 @@
 ALMA_API_KEY='YOUR_ALMA_API_KEY'
 ALMA_API_HOST='https://api-na.hosted.exlibrisgroup.com'
 STUDENT_USERS_SET_ID="YOUR_USERS_SET_ID"
+
+DIGIFEEDS_SET_ID="some_set_id"
+CHANGE_PHYSICAL_ITEM_INFORMATION_JOB_ID="some_job_id"

--- a/lib/aim.rb
+++ b/lib/aim.rb
@@ -4,6 +4,7 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require "thor"
 require "aim/student_workers"
+require "aim/hathi_trust"
 require "aim/cli"
 
 module AIM

--- a/lib/aim/cli.rb
+++ b/lib/aim/cli.rb
@@ -4,12 +4,27 @@ module AIM
       true
     end
 
+    class HathiTrust < Thor
+      desc "set_digitizer", "sets digitizer for digifeeds items"
+      long_desc <<~DESC
+        Triggers the "Change Physical items information job" on the digifeeds
+        set so that Statistics Note 3 has the value "umich". This will tell Google
+        that Umich is the digitizer of the item. 
+      DESC
+      def set_digitizer
+        AIM::HathiTrust::DigitizerSetter.new.run
+      end
+    end
+
     class StudentWorkers < Thor
       desc "expire_passwords", "expires student worker passwords"
       def expire_passwords
         AIM::StudentWorkers::PasswordExpirer.new.run
       end
     end
+
+    desc "ht SUBCOMMAND", "commands related to the HathiTrust and Google Books project"
+    subcommand "ht", HathiTrust
 
     desc "student_workers SUBCOMMAND", "commands related to student workers"
     subcommand "student_workers", StudentWorkers

--- a/lib/aim/hathi_trust.rb
+++ b/lib/aim/hathi_trust.rb
@@ -1,0 +1,8 @@
+require "alma_rest_client"
+require "logger"
+require "aim/hathi_trust/digitizer_setter"
+
+module AIM
+  module HathiTrust
+  end
+end

--- a/lib/aim/hathi_trust/digitizer_setter.rb
+++ b/lib/aim/hathi_trust/digitizer_setter.rb
@@ -1,0 +1,48 @@
+module AIM
+  module HathiTrust
+    class DigitizerSetter
+      def initialize(logger: Logger.new($stdout))
+        @logger = logger
+      end
+
+      def run
+        @logger.info("Sending Change Physical Item Job to set the Digitizer to Umich for Digifeeds")
+        resp = AlmaRestClient.client.post("/conf/jobs/#{ENV.fetch("CHANGE_PHYSICAL_ITEM_INFORMATION_JOB_ID")}?op=run", body: body)
+        @logger.info resp.body
+        if resp.status == 200
+          @logger.info("Finished Sending Change Physical Items job")
+        else
+          @logger.error("Failed to send job")
+        end
+      end
+
+      def body
+        {
+          "parameter" => params.map do |name, value|
+            {
+              "name" => {"value" => name, "desc" => name},
+              "value" => value
+            }
+          end
+        }
+      end
+
+      def params
+        {
+          "STATISTICS_NOTE_3_value" => digitizer,
+          "STATISTICS_NOTE_3_selected" => true,
+          "set_id" => ENV.fetch("DIGIFEEDS_SET_ID"),
+          "job_name" => job_name
+        }
+      end
+
+      def digitizer
+        "umich"
+      end
+
+      def job_name
+        "Change Physical items information - set digitizer to Umich"
+      end
+    end
+  end
+end

--- a/spec/aim/hathi_trust/digitizer_setter_spec.rb
+++ b/spec/aim/hathi_trust/digitizer_setter_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe AIM::HathiTrust::DigitizerSetter do
+  it "triggers a change physical items information job;" do
+    logger_double = instance_double(Logger, info: nil)
+    body =
+      {"parameter" =>
+       [
+         {"name" => {"value" => "STATISTICS_NOTE_3_value", "desc" => "STATISTICS_NOTE_3_value"}, "value" => "umich"},
+         {"name" => {"value" => "STATISTICS_NOTE_3_selected", "desc" => "STATISTICS_NOTE_3_selected"}, "value" => true},
+         {"name" => {"value" => "set_id", "desc" => "set_id"}, "value" => ENV.fetch("DIGIFEEDS_SET_ID")},
+         {"name" => {"value" => "job_name", "desc" => "job_name"}, "value" => "Change Physical items information - set digitizer to Umich"}
+       ]}
+
+    request = stub_alma_post_request(url: "conf/jobs/#{ENV.fetch("CHANGE_PHYSICAL_ITEM_INFORMATION_JOB_ID")}?op=run", input: body)
+    described_class.new(logger: logger_double).run
+    expect(request).to have_been_requested
+  end
+end


### PR DESCRIPTION
Per a meeting with the content ingest team, the digifeeds workflow involves setting the digitizer to the value `umich`. The digitizer is the Statistics Note 3. `ht set_digitizer` will trigger the job to set the value on the digifeeds set in alma.