### PR TITLE
Update Workflows and rename ht command

### DIFF
--- a/.github/workflows/build-deploy-on-release.yaml
+++ b/.github/workflows/build-deploy-on-release.yaml
@@ -16,7 +16,7 @@ jobs:
 
   deploy-production-default:
     needs: build-production
-    name: Deploy to production
+    name: Deploy to production - default
     uses: mlibrary/platform-engineering-workflows/.github/workflows/deploy.yml@v1
     with:
       image: ghcr.io/mlibrary/${{ vars.IMAGE_NAME }}:${{ github.event.release.tag_name }}
@@ -28,7 +28,7 @@ jobs:
 
   deploy-production-hathifiles:
     needs: build-production
-    name: Deploy to production
+    name: Deploy to production - hathifiles
     uses: mlibrary/platform-engineering-workflows/.github/workflows/deploy.yml@v1
     with:
       image: ghcr.io/mlibrary/${{ vars.IMAGE_NAME }}:${{ github.event.release.tag_name }}

--- a/.github/workflows/manual-deploy-production.yaml
+++ b/.github/workflows/manual-deploy-production.yaml
@@ -19,7 +19,7 @@ jobs:
 
   deploy-production-default:
     needs: build-production
-    name: Deploy to production
+    name: Deploy to production - default
     uses: mlibrary/platform-engineering-workflows/.github/workflows/deploy.yml@v1
     with:
       image: ghcr.io/mlibrary/${{ vars.IMAGE_NAME }}:${{ github.event.inputs.tag }}
@@ -31,7 +31,7 @@ jobs:
 
   deploy-production-hathifiles:
     needs: build-production
-    name: Deploy to production
+    name: Deploy to production - hathifiles
     uses: mlibrary/platform-engineering-workflows/.github/workflows/deploy.yml@v1
     with:
       image: ghcr.io/mlibrary/${{ vars.IMAGE_NAME }}:${{ github.event.inputs.tag }}

--- a/.github/workflows/manual-deploy-workshop.yaml
+++ b/.github/workflows/manual-deploy-workshop.yaml
@@ -18,7 +18,7 @@ jobs:
 
   deploy-workshop-default:
     needs: build-unstable
-    name: Deploy to workshop
+    name: Deploy to workshop - default
     uses: mlibrary/platform-engineering-workflows/.github/workflows/deploy.yml@v1
     with:
       image: ${{ needs.build-unstable.outputs.image }}
@@ -30,7 +30,7 @@ jobs:
 
   deploy-workshop-hathifiles:
     needs: build-unstable
-    name: Deploy to workshop
+    name: Deploy to workshop - hathifiles
     uses: mlibrary/platform-engineering-workflows/.github/workflows/deploy.yml@v1
     with:
       image: ${{ needs.build-unstable.outputs.image }}

--- a/lib/aim/cli/hathi_trust.rb
+++ b/lib/aim/cli/hathi_trust.rb
@@ -19,7 +19,7 @@ end
 
 module AIM
   class CLI
-    desc "ht SUBCOMMAND", "commands related to the HathiTrust and Google Books project"
-    subcommand "ht", HathiTrust
+    desc "hathi_trust SUBCOMMAND", "commands related to the HathiTrust and Google Books project"
+    subcommand "hathi_trust", HathiTrust
   end
 end


### PR DESCRIPTION
For the deployment workflows, specifies where the file is being deployed to.

Changes the `ht` command to `hathi_trust`