### PR TITLE
remove github ruby package manager

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,6 @@ jobs:
         with:
           ruby-version: 3.4
           bundler-cache: true
-        env: 
-          BUNDLE_RUBYGEMS__PKG__GITHUB__COM: ${{secrets.GITHUB_TOKEN}}
       - name: Run linter for Ruby
         run: bundle exec standardrb
       - name: Run tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,4 @@ FROM development AS production
 
 COPY --chown=${UID}:${GID} . /app
 
-RUN --mount=type=secret,id=github_token,uid=1000 \
-  github_token="$(cat /run/secrets/github_token)" \
-  && BUNDLE_RUBYGEMS__PKG__GITHUB__COM=${github_token} bundle install
+RUN bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,12 @@
 source "https://rubygems.org"
 
-source "https://rubygems.pkg.github.com/mlibrary" do
-  gem "alma_rest_client", "~> 2.0"
-  gem "sftp"
-end
+gem "alma_rest_client",
+  git: "https://github.com/mlibrary/alma_rest_client",
+  tag: "alma_rest_client/v2.2.0"
+
+gem "sftp",
+  git: "https://github.com/mlibrary/sftp",
+  tag: "sftp/v0.4.2"
 
 gem "hathifiles_database",
   git: "https://github.com/hathitrust/hathifiles_database",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,25 @@ GIT
       sqlite3
       tty-prompt
 
+GIT
+  remote: https://github.com/mlibrary/alma_rest_client
+  revision: f94276a6e83d1526f7ec91c66aad1cee8b80f97d
+  tag: alma_rest_client/v2.2.0
+  specs:
+    alma_rest_client (2.2.0)
+      activesupport (~> 8.0)
+      faraday
+      faraday-retry
+      httpx
+      rexml
+
+GIT
+  remote: https://github.com/mlibrary/sftp
+  revision: 7d9ae3ca8628699c8e5304319184835a0a843dd2
+  tag: sftp/v0.4.2
+  specs:
+    sftp (0.4.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -212,22 +231,11 @@ GEM
       yabeda (~> 0.10)
     zeitwerk (2.7.3)
 
-GEM
-  remote: https://rubygems.pkg.github.com/mlibrary/
-  specs:
-    alma_rest_client (2.2.0)
-      activesupport (~> 8.0)
-      faraday
-      faraday-retry
-      httpx
-      rexml
-    sftp (0.4.2)
-
 PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  alma_rest_client (~> 2.0)!
+  alma_rest_client!
   canister
   climate_control
   hathifiles_database!


### PR DESCRIPTION
Using the GitHub ruby package manager is kind of brittle. Dependabot would need to be configured to use it. Instead we're moving to just using GitHub for gems that aren't general ruby gems. 